### PR TITLE
Fchk fix

### DIFF
--- a/opencap/CMakeLists.txt
+++ b/opencap/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(opencap ${HDF5_LIBRARIES} numgrid-objects pybind11::module
 target_link_libraries(opencap-shared ${HDF5_LIBRARIES} numgrid-objects pybind11::module pybind11::embed Eigen3::Eigen h5pp::h5pp)
 
 install(TARGETS opencap
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
     )
 enable_testing()
 add_subdirectory(tests)

--- a/opencap/src/InputParser.cpp
+++ b/opencap/src/InputParser.cpp
@@ -147,6 +147,7 @@ std::tuple<System,std::map<std::string,std::string>> parse_input(std::string inp
 		else
 			opencap_throw("Invalid jobtype: \'" + parameters["jobtype"]);
 		my_sys = get_System(input_file,get_params_for_field(parameters,"system"));
+        
 	}
 	catch (exception &e)
 	{

--- a/opencap/src/qchem_interface.cpp
+++ b/opencap/src/qchem_interface.cpp
@@ -328,7 +328,7 @@ std::vector<Atom> read_geometry_from_fchk(std::string fchk_filename)
     			opencap_throw("Error: Reached end of file before atomic numbers were found.");
 		}
 		size_t num_elements = stoi(split(line,' ').back());
-		size_t lines_to_read = num_elements%5==0 ? (num_elements/5) : num_elements/5+1;
+		size_t lines_to_read = num_elements%6==0 ? (num_elements/6) : num_elements/6+1;
 		for (size_t k=1;k<=lines_to_read;k++)
 		{
 			std::getline(is,line);

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pyopencap',
-    version='1.0.0',
+    version='1.0.1',
     author='James Gayvert',
     author_email='jrg444@gmail.com',
     description='Python bindings for OpenCAP',


### PR DESCRIPTION
Fixes bug in .fchk parser for reading in atomic numbers. 
Make install installs to bin directory